### PR TITLE
Update stubs

### DIFF
--- a/test/cbmc/include/stubs.h
+++ b/test/cbmc/include/stubs.h
@@ -109,3 +109,6 @@ OtaPalStatus_t createFilePalStub( OtaFileContext_t * const pFileContext );
 
 /* Stub to request a fileblock from the Data plane. */
 OtaErr_t requestFileBlockStub( OtaAgentContext_t * pAgentCtx );
+
+/* Stub to delete timer. */
+OtaOsStatus_t deleteTimerStub ( OtaTimerId_t otaTimerId );

--- a/test/cbmc/proofs/OTA_Resume/Makefile
+++ b/test/cbmc/proofs/OTA_Resume/Makefile
@@ -16,6 +16,9 @@ NONDET_STATIC += "--nondet-static"
 
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
+RESTRICT_FUNCTION_POINTER += OTA_Resume.function_pointer_call.1/startTimerStub
+RESTRICT_FUNCTION_POINTER += OTA_Resume.function_pointer_call.2/startTimerStub
+
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the

--- a/test/cbmc/proofs/OTA_Resume/OTA_Resume_harness.c
+++ b/test/cbmc/proofs/OTA_Resume/OTA_Resume_harness.c
@@ -26,6 +26,9 @@
  */
 /*  Ota Agent includes. */
 #include "ota.h"
+#include "stubs.h"
+
+extern OtaAgentContext_t otaAgent;
 
 bool OTA_SignalEvent( const OtaEventMsg_t * const pEventMsg )
 {
@@ -36,5 +39,11 @@ bool OTA_SignalEvent( const OtaEventMsg_t * const pEventMsg )
 
 void OTA_Resume_harness()
 {
+    OtaInterfaces_t otaInterface;
+
+    /* Initialize os timers. */
+    otaInterface.os.timer.start = startTimerStub;
+    otaAgent.pOtaInterface = &otaInterface;
+
     OTA_Resume();
 }

--- a/test/cbmc/proofs/OTA_Shutdown/Makefile
+++ b/test/cbmc/proofs/OTA_Shutdown/Makefile
@@ -18,6 +18,11 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
+RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.1/stopTimerStub
+RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.2/deleteTimerStub
+RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.3/stopTimerStub
+RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.4/deleteTimerStub
+
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the

--- a/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
+++ b/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
@@ -26,6 +26,7 @@
  */
 /*  Ota Agent includes. */
 #include "ota.h"
+#include "stubs.h"
 
 extern OtaAgentContext_t otaAgent;
 
@@ -34,8 +35,15 @@ void OTA_Shutdown_harness()
     OtaState_t state;
     uint32_t ticksToWait;
     uint8_t unsubscribeFlag;
+    OtaInterfaces_t otaInterface;
 
     otaAgent.state = state;
+
+    /* Initialize os timers functions. */
+    otaInterface.os.timer.stop = stopTimerStub;
+    otaInterface.os.timer.delete = deleteTimerStub;
+
+    otaAgent.pOtaInterface = &otaInterface;
 
     /* This assumption is required to have an upper bound on the unwinding of while loop in
      * OTA_Shutdown. This does not model the exact behavior of the code since the limitation of CBMC

--- a/test/cbmc/source/stubs.c
+++ b/test/cbmc/source/stubs.c
@@ -304,3 +304,16 @@ OtaErr_t requestFileBlockStub( OtaAgentContext_t * pAgentCtx )
 
     return err;
 }
+
+OtaOsStatus_t deleteTimerStub( OtaTimerId_t otaTimerId )
+{
+    OtaOsStatus_t status;
+
+    /* status must have values only from the OtaOsStatus_t enum. */
+    __CPROVER_assume( ( status >= OtaOsSuccess ) && ( status <= OtaOsTimerDeleteFailed ) );
+
+    __CPROVER_assert( ( otaTimerId == OtaSelfTestTimer ) || ( otaTimerId == OtaRequestTimer ),
+                      "Error: Expected otaTimerId to be either OtaSelfTestTimer or OtaRequestTimer." );
+
+    return status;
+}


### PR DESCRIPTION
This PR fixes the function pointer call issue in the CBMC proof of OTA_Resume and OTA_Shutdown

Description
-----------
Added initialization of the function pointers in the CBMC proofs of OTA_Resume and OTA_Shutdown functions respectively. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [ ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.